### PR TITLE
Add flashlight mechanic with battery system (#56)

### DIFF
--- a/src/faultline-fear/client/Controllers/FlashlightController.luau
+++ b/src/faultline-fear/client/Controllers/FlashlightController.luau
@@ -1,0 +1,278 @@
+--!strict
+--[[
+	Faultline Fear: Flashlight Controller (Client)
+
+	Handles flashlight rendering, input, and effects.
+	Syncs with server for battery management.
+
+	Features:
+	- Toggle on/off with F key
+	- Light cone attached to character head
+	- Battery drain/warning effects
+	- Flicker when low battery
+	- Visual feedback for other players
+
+	Exports: Initialize()
+	Depends: InputService
+]]
+
+local ContextActionService = game:GetService("ContextActionService")
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local Player = Players.LocalPlayer
+
+local FlashlightController = {}
+
+-- State
+local isOn: boolean = false
+local battery: number = 100 -- 0-100 percentage
+local flashlight: SpotLight? = nil
+local attachment: Attachment? = nil
+local flickerTime: number = 0
+
+-- Constants
+local FLASHLIGHT_ANGLE = 45
+local FLASHLIGHT_RANGE = 60
+local FLASHLIGHT_BRIGHTNESS = 2
+local LOW_BATTERY_THRESHOLD = 20
+local FLICKER_INTENSITY = 0.3 -- How much brightness varies when flickering
+local FLICKER_SPEED = 10 -- Flicker frequency
+
+-- Remote events
+local Remotes: Folder? = nil
+local FlashlightToggle: RemoteEvent? = nil
+local FlashlightUpdate: RemoteEvent? = nil
+
+-- ==========================================
+-- FLASHLIGHT CREATION
+-- ==========================================
+
+local function createFlashlight(character: Model): SpotLight?
+	local head = character:FindFirstChild("Head")
+	if not head then return nil end
+
+	-- Create attachment for light
+	local attach = Instance.new("Attachment")
+	attach.Name = "FlashlightAttachment"
+	attach.Position = Vector3.new(0, 0.2, -0.5) -- Slightly in front of face
+	attach.Parent = head
+
+	-- Create spotlight
+	local light = Instance.new("SpotLight")
+	light.Name = "Flashlight"
+	light.Angle = FLASHLIGHT_ANGLE
+	light.Range = FLASHLIGHT_RANGE
+	light.Brightness = FLASHLIGHT_BRIGHTNESS
+	light.Face = Enum.NormalId.Front
+	light.Shadows = true
+	light.Enabled = false
+	light.Parent = attach
+
+	attachment = attach
+	return light
+end
+
+local function destroyFlashlight()
+	if attachment then
+		attachment:Destroy()
+		attachment = nil
+	end
+	flashlight = nil
+end
+
+-- ==========================================
+-- FLASHLIGHT CONTROL
+-- ==========================================
+
+local function setFlashlightEnabled(enabled: boolean)
+	if not flashlight then return end
+
+	isOn = enabled
+	flashlight.Enabled = enabled
+
+	-- Notify server
+	if FlashlightToggle then
+		FlashlightToggle:FireServer(enabled)
+	end
+end
+
+local function toggleFlashlight()
+	-- Don't allow toggle if no battery
+	if battery <= 0 and not isOn then
+		-- Play empty click sound?
+		return
+	end
+
+	setFlashlightEnabled(not isOn)
+end
+
+-- ==========================================
+-- BATTERY & EFFECTS
+-- ==========================================
+
+local function updateFlashlightEffects(dt: number)
+	if not flashlight or not isOn then return end
+
+	-- Flicker effect when low battery
+	if battery <= LOW_BATTERY_THRESHOLD then
+		flickerTime += dt * FLICKER_SPEED
+
+		-- Random flicker intensity
+		local flicker = 1 - (math.sin(flickerTime) * 0.5 + 0.5) * FLICKER_INTENSITY
+		if battery <= 5 then
+			-- More intense flicker when very low
+			flicker = flicker * (0.5 + math.random() * 0.5)
+		end
+
+		flashlight.Brightness = FLASHLIGHT_BRIGHTNESS * flicker
+	else
+		flashlight.Brightness = FLASHLIGHT_BRIGHTNESS
+	end
+
+	-- Auto turn off when battery depleted
+	if battery <= 0 and isOn then
+		setFlashlightEnabled(false)
+	end
+end
+
+-- ==========================================
+-- INPUT HANDLING
+-- ==========================================
+
+local function handleFlashlightInput(actionName: string, inputState: Enum.UserInputState, _inputObject: InputObject): Enum.ContextActionResult
+	if actionName ~= "ToggleFlashlight" then
+		return Enum.ContextActionResult.Pass
+	end
+
+	if inputState == Enum.UserInputState.Begin then
+		toggleFlashlight()
+		return Enum.ContextActionResult.Sink
+	end
+
+	return Enum.ContextActionResult.Pass
+end
+
+-- ==========================================
+-- CHARACTER HANDLING
+-- ==========================================
+
+local function onCharacterAdded(character: Model)
+	-- Wait for head to load
+	local head = character:WaitForChild("Head", 5)
+	if not head then return end
+
+	-- Create flashlight
+	flashlight = createFlashlight(character)
+
+	-- Sync with server state
+	if FlashlightToggle then
+		FlashlightToggle:FireServer(isOn)
+	end
+end
+
+local function onCharacterRemoving(_character: Model)
+	destroyFlashlight()
+	isOn = false
+end
+
+-- ==========================================
+-- SERVER COMMUNICATION
+-- ==========================================
+
+local function onBatteryUpdate(newBattery: number)
+	battery = newBattery
+end
+
+local function onOtherPlayerFlashlightToggle(player: Player, enabled: boolean)
+	-- Show/hide other player's flashlight
+	local character = player.Character
+	if not character then return end
+
+	local head = character:FindFirstChild("Head")
+	if not head then return end
+
+	local attach = head:FindFirstChild("FlashlightAttachment")
+	if enabled and not attach then
+		-- Create visual flashlight for other player
+		attach = Instance.new("Attachment")
+		attach.Name = "FlashlightAttachment"
+		attach.Position = Vector3.new(0, 0.2, -0.5)
+		attach.Parent = head
+
+		local light = Instance.new("SpotLight")
+		light.Name = "Flashlight"
+		light.Angle = FLASHLIGHT_ANGLE
+		light.Range = FLASHLIGHT_RANGE * 0.8 -- Slightly less range for others
+		light.Brightness = FLASHLIGHT_BRIGHTNESS * 0.8
+		light.Face = Enum.NormalId.Front
+		light.Shadows = false -- No shadows for performance
+		light.Enabled = true
+		light.Parent = attach
+	elseif not enabled and attach then
+		attach:Destroy()
+	elseif attach then
+		local light = attach:FindFirstChild("Flashlight")
+		if light and light:IsA("SpotLight") then
+			light.Enabled = enabled
+		end
+	end
+end
+
+-- ==========================================
+-- PUBLIC API
+-- ==========================================
+
+function FlashlightController:IsOn(): boolean
+	return isOn
+end
+
+function FlashlightController:GetBattery(): number
+	return battery
+end
+
+function FlashlightController:SetBattery(value: number)
+	battery = math.clamp(value, 0, 100)
+end
+
+function FlashlightController:Initialize()
+	-- Wait for remotes
+	Remotes = ReplicatedStorage:WaitForChild("Remotes", 10) :: Folder?
+	if Remotes then
+		FlashlightToggle = Remotes:FindFirstChild("FlashlightToggle") :: RemoteEvent?
+		FlashlightUpdate = Remotes:FindFirstChild("FlashlightUpdate") :: RemoteEvent?
+
+		if FlashlightUpdate then
+			FlashlightUpdate.OnClientEvent:Connect(function(updateType: string, data: any)
+				if updateType == "battery" then
+					onBatteryUpdate(data)
+				elseif updateType == "playerToggle" then
+					onOtherPlayerFlashlightToggle(data.player, data.enabled)
+				end
+			end)
+		end
+	end
+
+	-- Bind input
+	ContextActionService:BindAction(
+		"ToggleFlashlight",
+		handleFlashlightInput,
+		false,
+		Enum.KeyCode.F
+	)
+
+	-- Handle character
+	if Player.Character then
+		task.spawn(onCharacterAdded, Player.Character)
+	end
+	Player.CharacterAdded:Connect(onCharacterAdded)
+	Player.CharacterRemoving:Connect(onCharacterRemoving)
+
+	-- Update loop for effects
+	RunService.RenderStepped:Connect(updateFlashlightEffects)
+
+	print("[FlashlightController] Initialized")
+end
+
+return FlashlightController

--- a/src/faultline-fear/client/Main.client.luau
+++ b/src/faultline-fear/client/Main.client.luau
@@ -61,6 +61,7 @@ local PerformanceController = require(script.Controllers.PerformanceController)
 local CreditsController = require(script.Controllers.CreditsController)
 local DialogueController = require(script.Controllers.DialogueController)
 local BeaconController = require(script.Controllers.BeaconController)
+local FlashlightController = require(script.Controllers.FlashlightController)
 -- TODO: Initialize other controllers
 -- local CameraController = require(script.Controllers.CameraController)
 
@@ -72,6 +73,7 @@ PerformanceController:Initialize() -- FPS monitoring, battery saver
 CreditsController:Initialize() -- Ending sequence
 DialogueController:Initialize() -- NPC dialogue UI
 BeaconController:Initialize() -- Objective beacons
+FlashlightController:Initialize() -- Flashlight with battery
 
 -- ==========================================
 -- REMOTE EVENT HANDLERS
@@ -131,11 +133,7 @@ if InputService:HasPhysicalKeyboard() then
 			print("[FaultlineFear Client] Eat food (not implemented)")
 		end
 
-		-- Flashlight
-		if input.KeyCode == Config.KEYBINDS.FLASHLIGHT then
-			-- TODO: Toggle flashlight
-			print("[FaultlineFear Client] Toggle flashlight (not implemented)")
-		end
+		-- Flashlight handled by FlashlightController via ContextActionService
 
 		-- Call pet
 		if input.KeyCode == Config.KEYBINDS.CALL_PET then

--- a/src/faultline-fear/server/Main.server.luau
+++ b/src/faultline-fear/server/Main.server.luau
@@ -121,6 +121,7 @@ local StructureSpawner = require(script.Services.StructureSpawner)
 local PetService = require(script.Services.PetService)
 local TerrainAssetSpawner = require(script.Services.TerrainAssetSpawner)
 local AnimalService = require(script.Services.AnimalService)
+local FlashlightService = require(script.Services.FlashlightService)
 
 -- Initialize all services
 TerrainGenerator:Initialize()
@@ -139,6 +140,7 @@ CreatureService:SetDayNightService(DayNightService)
 PetService:SetCreatureService(CreatureService)
 PetService:SetEarthquakeService(EarthquakeService)
 AnimalService:SetDayNightService(DayNightService)
+FlashlightService:SetCreatureService(CreatureService)
 
 -- Initialize creature spawning (after DayNightService connection)
 CreatureService:Initialize()
@@ -148,6 +150,9 @@ PetService:Initialize()
 
 -- Initialize wildlife (after DayNightService connection)
 AnimalService:Initialize()
+
+-- Initialize flashlight system
+FlashlightService:Initialize()
 
 -- Initialize story zones BEFORE StoryBeatProcessor (it listens for StoryZone tags)
 StoryZoneManager:Initialize()

--- a/src/faultline-fear/server/Services/FlashlightService.luau
+++ b/src/faultline-fear/server/Services/FlashlightService.luau
@@ -1,0 +1,192 @@
+--!strict
+--[[
+	Faultline Fear: Flashlight Service (Server)
+
+	Manages flashlight battery and state synchronization.
+
+	Features:
+	- Battery drain while flashlight is on
+	- Battery collectible integration
+	- State sync between players
+	- Creature attraction (risk/reward)
+
+	Exports: Initialize(), GetBattery(), AddBattery()
+	Depends: Config
+]]
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local Shared = require(ReplicatedStorage:WaitForChild("Shared"))
+local _Config = Shared.Config -- May be used for flashlight tuning
+
+local FlashlightService = {}
+
+-- State
+local playerBattery: { [Player]: number } = {}
+local playerFlashlightOn: { [Player]: boolean } = {}
+
+-- Constants
+local MAX_BATTERY = 100
+local BATTERY_DRAIN_PER_SECOND = 100 / (5 * 60) -- 5 minutes of use
+local BATTERY_COLLECTIBLE_AMOUNT = 25 -- How much battery a collectible gives
+
+-- Remote events
+local Remotes: Folder = nil :: any
+local FlashlightToggle: RemoteEvent = nil :: any
+local FlashlightUpdate: RemoteEvent = nil :: any
+
+-- External service references
+local _CreatureService: any = nil -- Set via SetCreatureService, for future creature attraction
+
+-- ==========================================
+-- STATE SYNC
+-- ==========================================
+
+local function broadcastFlashlightState(player: Player, enabled: boolean)
+	-- Tell all other players about this player's flashlight state
+	for _, otherPlayer in Players:GetPlayers() do
+		if otherPlayer ~= player then
+			FlashlightUpdate:FireClient(otherPlayer, "playerToggle", {
+				player = player,
+				enabled = enabled,
+			})
+		end
+	end
+end
+
+-- ==========================================
+-- BATTERY MANAGEMENT
+-- ==========================================
+
+local function drainBattery(player: Player, dt: number)
+	if not playerFlashlightOn[player] then return end
+
+	local current = playerBattery[player] or MAX_BATTERY
+	local newBattery = math.max(0, current - BATTERY_DRAIN_PER_SECOND * dt)
+
+	if newBattery ~= current then
+		playerBattery[player] = newBattery
+
+		-- Notify client of battery change
+		FlashlightUpdate:FireClient(player, "battery", newBattery)
+
+		-- Auto turn off if depleted
+		if newBattery <= 0 then
+			playerFlashlightOn[player] = false
+			broadcastFlashlightState(player, false)
+		end
+	end
+end
+
+local function updateAllBatteries(dt: number)
+	for player in pairs(playerFlashlightOn) do
+		if player.Parent then -- Still in game
+			drainBattery(player, dt)
+		end
+	end
+end
+
+-- ==========================================
+-- TOGGLE HANDLING
+-- ==========================================
+
+local function onFlashlightToggle(player: Player, enabled: boolean)
+	-- Validate battery
+	local battery = playerBattery[player] or MAX_BATTERY
+	if enabled and battery <= 0 then
+		-- Can't turn on with no battery
+		FlashlightUpdate:FireClient(player, "battery", 0)
+		return
+	end
+
+	playerFlashlightOn[player] = enabled
+	broadcastFlashlightState(player, enabled)
+
+	-- Note: Creature attraction when flashlight is on would be handled by CreatureService
+	-- This creates risk/reward - light helps you see but attracts danger
+
+	print(string.format("[FlashlightService] %s flashlight: %s", player.Name, enabled and "ON" or "OFF"))
+end
+
+-- ==========================================
+-- PLAYER HANDLING
+-- ==========================================
+
+local function onPlayerAdded(player: Player)
+	-- Initialize battery
+	playerBattery[player] = MAX_BATTERY
+	playerFlashlightOn[player] = false
+end
+
+local function onPlayerRemoving(player: Player)
+	-- Clean up
+	playerBattery[player] = nil
+	playerFlashlightOn[player] = nil
+end
+
+-- ==========================================
+-- PUBLIC API
+-- ==========================================
+
+function FlashlightService:GetBattery(player: Player): number
+	return playerBattery[player] or MAX_BATTERY
+end
+
+function FlashlightService:SetBattery(player: Player, amount: number)
+	playerBattery[player] = math.clamp(amount, 0, MAX_BATTERY)
+	FlashlightUpdate:FireClient(player, "battery", playerBattery[player])
+end
+
+function FlashlightService:AddBattery(player: Player, amount: number)
+	local current = playerBattery[player] or MAX_BATTERY
+	self:SetBattery(player, current + amount)
+end
+
+function FlashlightService:CollectBattery(player: Player)
+	-- Called when player collects a battery item
+	self:AddBattery(player, BATTERY_COLLECTIBLE_AMOUNT)
+	print(string.format("[FlashlightService] %s collected battery (+%d%%)", player.Name, BATTERY_COLLECTIBLE_AMOUNT))
+end
+
+function FlashlightService:IsFlashlightOn(player: Player): boolean
+	return playerFlashlightOn[player] or false
+end
+
+function FlashlightService:SetCreatureService(service: any)
+	_CreatureService = service
+end
+
+function FlashlightService:Initialize()
+	-- Get/create remotes
+	Remotes = ReplicatedStorage:WaitForChild("Remotes") :: Folder
+
+	-- Create flashlight-specific remotes
+	FlashlightToggle = Instance.new("RemoteEvent")
+	FlashlightToggle.Name = "FlashlightToggle"
+	FlashlightToggle.Parent = Remotes
+
+	FlashlightUpdate = Instance.new("RemoteEvent")
+	FlashlightUpdate.Name = "FlashlightUpdate"
+	FlashlightUpdate.Parent = Remotes
+
+	-- Listen for toggle events from clients
+	FlashlightToggle.OnServerEvent:Connect(onFlashlightToggle)
+
+	-- Player handling
+	Players.PlayerAdded:Connect(onPlayerAdded)
+	Players.PlayerRemoving:Connect(onPlayerRemoving)
+
+	-- Initialize existing players
+	for _, player in Players:GetPlayers() do
+		onPlayerAdded(player)
+	end
+
+	-- Battery drain loop
+	RunService.Heartbeat:Connect(updateAllBatteries)
+
+	print("[FlashlightService] Initialized")
+end
+
+return FlashlightService


### PR DESCRIPTION
## Summary
- Complete flashlight system with client-server sync
- Battery management with drain and collectibles
- Visual effects for low battery

## Client Features
- F key toggle on/off
- SpotLight (45° angle, 60 stud range)
- Attached to player's head
- Flicker effect at <20% battery
- More intense flicker at <5%
- Shows other players' flashlights

## Server Features
- Battery starts at 100%
- Drains at ~5 minutes total use
- 25% battery per collectible
- Auto turn-off when depleted
- State sync to all players

## Integration
- Remote events for toggle/update
- Ready for battery collectibles
- Ready for creature attraction (future)

## Test plan
- [ ] Press F to toggle flashlight
- [ ] Light illuminates dark areas
- [ ] Battery drains over time
- [ ] Flicker when battery low
- [ ] Other players see your flashlight
- [ ] Can't turn on with 0% battery

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)