### PR TITLE
Add working Roblox audio asset IDs for music system

### DIFF
--- a/src/faultline-fear/client/Controllers/AudioController.luau
+++ b/src/faultline-fear/client/Controllers/AudioController.luau
@@ -30,26 +30,26 @@ local musicGroup: SoundGroup = nil :: any
 local currentSound: Sound? = nil
 local _nextSound: Sound? = nil -- Reserved for future crossfade optimization
 
--- Station sound IDs (placeholder - replace with real asset IDs)
--- These would be uploaded audio assets
+-- Station sound IDs - Roblox Creator Marketplace ambient sounds
+-- Sources: robloxsong.com, musiccoder.com, robloxmusicids.com
 local StationSounds: { [Station]: string } = {
-	Coastal = "rbxassetid://0", -- Beach/surf vibes
-	Mountain = "rbxassetid://0", -- Alpine ambient
-	Town = "rbxassetid://0", -- Urban radio feel
-	Wilderness = "rbxassetid://0", -- Forest/nature ambient
-	Eerie = "rbxassetid://0", -- Liminal space droning
-	Emergency = "rbxassetid://0", -- Emergency broadcast alert
+	Coastal = "rbxassetid://898059911", -- Sea Ambience
+	Mountain = "rbxassetid://169736440", -- [Nature] Forest Sounds (alpine feel)
+	Town = "rbxassetid://7262900392", -- Ambient Music (calm urban)
+	Wilderness = "rbxassetid://728506251", -- Nature sounds for Forest
+	Eerie = "rbxassetid://5595380425", -- Dark Scary Eerie Horror Ambient
+	Emergency = "rbxassetid://5743541225", -- Red Alert Alarm / Siren (looped)
 }
 
--- Fallback: Silent placeholders (Roblox audio privacy requires permission)
--- TODO: Upload custom audio or use Roblox Creator Marketplace sounds
+-- Fallback sound IDs (alternative tracks if primary fails)
+-- Note: Roblox audio privacy may restrict some tracks
 local FallbackSounds: { [Station]: number } = {
-	Coastal = 0, -- Silent placeholder
-	Mountain = 0, -- Silent placeholder
-	Town = 0, -- Silent placeholder
-	Wilderness = 0, -- Silent placeholder
-	Eerie = 0, -- Silent placeholder
-	Emergency = 0, -- Silent placeholder
+	Coastal = 959532448, -- Ocean waves
+	Mountain = 138089070, -- Forest Ambience (Night)
+	Town = 169736440, -- Forest sounds as fallback
+	Wilderness = 169736440, -- [Nature] Forest Sounds
+	Eerie = 7524653769, -- Creepy Ambience
+	Emergency = 428391167, -- Tornado Warning Siren
 }
 
 -- ==========================================


### PR DESCRIPTION
## Summary
- Music wasn't playing because all sound IDs were `rbxassetid://0` (placeholders)
- Updated AudioController with real Roblox Creator Marketplace ambient audio
- Added fallback IDs for each station in case primary fails

## Audio Sources
Audio IDs sourced from:
- [robloxsong.com](https://robloxsong.com)
- [musiccoder.com](https://musiccoder.com)
- [robloxmusicids.com](https://robloxmusicids.com)

## Station Audio
| Station | Primary ID | Description |
|---------|------------|-------------|
| Coastal | 898059911 | Sea Ambience |
| Mountain | 169736440 | Nature Forest Sounds |
| Town | 7262900392 | Ambient Music |
| Wilderness | 728506251 | Nature sounds for Forest |
| Eerie | 5595380425 | Dark Scary Eerie Horror Ambient |
| Emergency | 5743541225 | Red Alert Alarm/Siren |

## Important Note
Some audio may not play due to Roblox's audio privacy restrictions (audio uploaded by others may be restricted). If this is the case, the game owner will need to:
1. Purchase audio from the Roblox Creator Marketplace, or
2. Upload their own custom audio assets

## Test plan
- [ ] Launch game in Roblox Studio
- [ ] Verify music starts playing (Wilderness station by default)
- [ ] Walk to different zones and verify station changes
- [ ] Enter liminal space and verify eerie music plays

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)