### PR TITLE
Fix pet companion not appearing and add visibility improvements

### DIFF
--- a/src/faultline-fear/server/Services/PetService.luau
+++ b/src/faultline-fear/server/Services/PetService.luau
@@ -258,6 +258,17 @@ local function createPetModel(): Model
 	model:SetAttribute("PetName", "Buddy")
 	model:SetAttribute("IsPet", true)
 
+	-- Add highlight effect so pet is always visible
+	local highlight = Instance.new("Highlight")
+	highlight.Name = "PetHighlight"
+	highlight.FillTransparency = 0.8
+	highlight.OutlineTransparency = 0.3
+	highlight.FillColor = Color3.fromRGB(255, 220, 150) -- Warm glow
+	highlight.OutlineColor = Color3.fromRGB(255, 180, 100) -- Orange outline
+	highlight.Enabled = true
+	highlight.Parent = model
+
+	print("[PetService] Created pet model with highlight")
 	return model
 end
 
@@ -512,27 +523,38 @@ end
 -- ==========================================
 
 function PetService:SpawnPet(player: Player)
+	print(string.format("[PetService] SpawnPet called for %s", player.Name))
+
 	if pets[player] then
+		print("[PetService] Player already has pet, skipping")
 		return
-	end -- Already has pet
+	end
 
 	local character = player.Character
 	if not character then
+		warn("[PetService] Cannot spawn pet - no character for player:", player.Name)
 		return
 	end
 
 	local playerRoot = character:FindFirstChild("HumanoidRootPart")
 	if not playerRoot then
+		warn("[PetService] Cannot spawn pet - no HumanoidRootPart for player:", player.Name)
 		return
 	end
 
 	-- Create pet
 	local pet = createPetModel()
+	if not pet then
+		warn("[PetService] Failed to create pet model!")
+		return
+	end
 
-	-- Position behind player
+	-- Position behind player (use player height instead of terrain if player is higher)
 	local spawnPos = playerRoot.Position - playerRoot.CFrame.LookVector * FOLLOW_DISTANCE
 	local terrainY = Heightmap:GetHeight(spawnPos.X, spawnPos.Z)
-	pet:PivotTo(CFrame.new(spawnPos.X, terrainY + 0.5, spawnPos.Z))
+	-- Use whichever is higher: terrain or slightly below player (in case player is in air)
+	local petY = math.max(terrainY + 0.5, playerRoot.Position.Y - 2)
+	pet:PivotTo(CFrame.new(spawnPos.X, petY, spawnPos.Z))
 
 	-- Parent
 	pet.Parent = petsFolder
@@ -547,7 +569,22 @@ function PetService:SpawnPet(player: Player)
 		idleTime = 0,
 	}
 
-	print(string.format("[PetService] Spawned pet for %s", player.Name))
+	print(
+		string.format(
+			"[PetService] Spawned pet 'Buddy' for %s at (%.1f, %.1f, %.1f)",
+			player.Name,
+			spawnPos.X,
+			petY,
+			spawnPos.Z
+		)
+	)
+
+	-- Initial greeting
+	task.delay(0.5, function()
+		if pet.Parent then
+			showDialogue(player, "idle")
+		end
+	end)
 end
 
 function PetService:DespawnPet(player: Player)
@@ -614,16 +651,30 @@ function PetService:Initialize()
 
 	-- Spawn pet when character loads
 	local function onCharacterAdded(player: Player, character: Model)
+		print(string.format("[PetService] onCharacterAdded for %s", player.Name))
+
 		-- Wait for character to be fully loaded
 		local humanoid = character:WaitForChild("Humanoid", 5)
 		if not humanoid then
+			warn("[PetService] Character has no Humanoid after 5s:", player.Name)
 			return
 		end
 
+		-- Wait for HumanoidRootPart too (important!)
+		local rootPart = character:WaitForChild("HumanoidRootPart", 5)
+		if not rootPart then
+			warn("[PetService] Character has no HumanoidRootPart after 5s:", player.Name)
+			return
+		end
+
+		print(string.format("[PetService] Character ready for %s, spawning pet in 1s", player.Name))
+
 		-- Small delay for everything to settle
 		task.delay(1, function()
-			if player.Parent then
+			if player.Parent and player.Character == character then
 				self:SpawnPet(player)
+			else
+				warn("[PetService] Player or character changed before pet spawn:", player.Name)
 			end
 		end)
 	end


### PR DESCRIPTION
## Summary
- Added **Highlight effect** to pet model (warm orange glow) so pet is always visible
- Added **comprehensive logging** throughout pet spawn flow for debugging
- Fixed potential race condition by waiting for HumanoidRootPart (not just Humanoid)
- Improved pet Y positioning to prevent spawning underground
- Added initial greeting dialogue when pet spawns

## What the Pet Does Now
"Buddy" the pet companion should:
1. Spawn behind the player with a visible orange highlight glow
2. Say a random idle message when spawning (e.g., "Are we there yet?")
3. Follow the player around
4. Get distracted by shiny things
5. Fall asleep if player is idle
6. Get scared by creatures and run to player
7. Warn player about nearby predators

## Test Plan
- [x] Lint passes (selene)
- [x] Format passes (stylua)
- [x] Lune tests pass (59/59)
- [ ] Manual verification: pet should appear behind player on spawn
- [ ] Manual verification: pet should have orange glow highlight
- [ ] Manual verification: pet should say something when spawning
- [ ] Console should show [PetService] logs tracking spawn flow

## Debugging
If pet still doesn't appear, check server console for these messages:
- `[PetService] onCharacterAdded for <name>` - Character loaded
- `[PetService] Character ready for <name>, spawning pet in 1s` - About to spawn
- `[PetService] Spawned pet 'Buddy' for <name> at (X, Y, Z)` - Pet created

Any warnings like "Cannot spawn pet - no character" indicate where the issue is.

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)