### PR TITLE
Raise signs above grass for better visibility

### DIFF
--- a/src/faultline-fear/server/Services/SignService.luau
+++ b/src/faultline-fear/server/Services/SignService.luau
@@ -319,11 +319,14 @@ end
 -- SIGN SPAWNING
 -- ==========================================
 
+-- Sign Y offset to ensure visibility above grass
+local SIGN_HEIGHT_OFFSET = 1.5
+
 local function spawnSign(def: SignDef): Model
 	local model = createSign(def)
 
-	-- Get terrain height
-	local y = Heightmap:GetHeight(def.position.X, def.position.Z)
+	-- Get terrain height and add offset to hover above grass
+	local y = Heightmap:GetHeight(def.position.X, def.position.Z) + SIGN_HEIGHT_OFFSET
 
 	-- Position and rotate
 	local cframe = CFrame.new(def.position.X, y, def.position.Z) * CFrame.Angles(0, math.rad(def.rotation), 0)


### PR DESCRIPTION
## Summary
Added 1.5 stud Y offset to sign positioning so grass doesn't obscure the sign posts.

## Change
```lua
-- Sign Y offset to ensure visibility above grass
local SIGN_HEIGHT_OFFSET = 1.5

local y = Heightmap:GetHeight(x, z) + SIGN_HEIGHT_OFFSET
```

## Test plan
- [x] Lint passes
- [ ] Signs should hover slightly above ground
- [ ] Post bottom should be visible above grass

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)