### PR TITLE
Fix survivor counter not updating after rescue

### DIFF
--- a/src/faultline-fear/client/Main.client.luau
+++ b/src/faultline-fear/client/Main.client.luau
@@ -49,6 +49,7 @@ local HungerUpdate = Remotes:WaitForChild("HungerUpdate") :: RemoteEvent
 local EarthquakeEvent = Remotes:WaitForChild("EarthquakeEvent") :: RemoteEvent
 local TimeUpdate = Remotes:WaitForChild("TimeUpdate") :: RemoteEvent
 local ObjectiveUpdate = Remotes:WaitForChild("ObjectiveUpdate") :: RemoteEvent
+local ProgressUpdate = Remotes:WaitForChild("ProgressUpdate") :: RemoteEvent
 
 -- ==========================================
 -- CONTROLLER INITIALIZATION
@@ -106,6 +107,11 @@ end)
 
 ObjectiveUpdate.OnClientEvent:Connect(function(objectiveData)
 	HUDController:UpdateObjective(objectiveData)
+end)
+
+ProgressUpdate.OnClientEvent:Connect(function(progressData)
+	HUDController:UpdateProgress(progressData)
+	print("[FaultlineFear Client] Progress update:", progressData)
 end)
 
 -- ==========================================

--- a/src/faultline-fear/server/Main.server.luau
+++ b/src/faultline-fear/server/Main.server.luau
@@ -51,6 +51,7 @@ local function createRemotes()
 		"EarthquakeEvent",
 		"TimeUpdate",
 		"ObjectiveUpdate",
+		"ProgressUpdate", -- Survivor count, generator parts
 		"StoryEvent",
 		"DialogueEvent",
 		"HeightmapReady",

--- a/src/faultline-fear/server/Services/NPCService.luau
+++ b/src/faultline-fear/server/Services/NPCService.luau
@@ -373,10 +373,11 @@ function NPCService:RescueSurvivor(player: Player, survivorId: string)
 		end
 	end
 
-	-- Play rescue dialogue via DialogueEvent
-	if survivorData then
-		local remotes = ReplicatedStorage:FindFirstChild("Remotes")
-		if remotes then
+	-- Play rescue dialogue via DialogueEvent and update progress
+	local remotes = ReplicatedStorage:FindFirstChild("Remotes")
+	if remotes then
+		-- Send dialogue
+		if survivorData then
 			local dialogueEvent = remotes:FindFirstChild("DialogueEvent")
 			if dialogueEvent then
 				(dialogueEvent :: RemoteEvent):FireClient(player, {
@@ -384,6 +385,16 @@ function NPCService:RescueSurvivor(player: Player, survivorId: string)
 					lines = survivorData.dialogue,
 				})
 			end
+		end
+
+		-- Send progress update with new survivor count
+		local progressEvent = remotes:FindFirstChild("ProgressUpdate") :: RemoteEvent?
+		if progressEvent then
+			local survivorCount = self:GetRescuedCount(player)
+			progressEvent:FireClient(player, {
+				survivors = survivorCount,
+			})
+			print(string.format("[NPCService] Sent progress update: survivors=%d", survivorCount))
 		end
 	end
 


### PR DESCRIPTION
## Summary
- Added ProgressUpdate RemoteEvent to server initialization
- NPCService now fires ProgressUpdate with survivor count after rescue
- Client listens for ProgressUpdate and calls HUDController:UpdateProgress

The HUD's survivor counter stayed at 0 because the entire data flow was missing:
1. The ProgressUpdate RemoteEvent didn't exist
2. NPCService wasn't sending progress updates after rescue
3. Client wasn't listening for progress updates

## Test plan
- [ ] Start game and find a survivor
- [ ] Hold E to rescue them
- [ ] Verify the Survivors counter in the HUD updates from 0 to 1
- [ ] Rescue additional survivors and verify counter increments

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)