### PR TITLE
Fix WriteVoxels array dimension mismatch in terrain generation

### DIFF
--- a/src/faultline-fear/server/Services/TerrainGenerator.luau
+++ b/src/faultline-fear/server/Services/TerrainGenerator.luau
@@ -156,10 +156,14 @@ function TerrainGenerator:GenerateVisualChunk(startX: number, startZ: number, si
 
 	-- Y dimension needs to accommodate full height range
 	-- Include buffer below sea level for ocean floor and above for safety
-	local minY = -50 -- Below sea level for ocean floor
-	local maxY = Config.MOUNTAIN_MAX_HEIGHT + 50 -- Above max mountains for safety
+	-- CRITICAL: Align to voxel grid to match ExpandToGrid behavior
+	local rawMinY = -50 -- Below sea level for ocean floor
+	local rawMaxY = Config.MOUNTAIN_MAX_HEIGHT + 50 -- Above max mountains for safety
+	-- Round down for minY, round up for maxY to ensure we cover the full range
+	local minY = math.floor(rawMinY / voxelSize) * voxelSize
+	local maxY = math.ceil(rawMaxY / voxelSize) * voxelSize
 	local heightRange = maxY - minY
-	local voxelsPerAxisY = math.ceil(heightRange / voxelSize)
+	local voxelsPerAxisY = heightRange / voxelSize -- Exact division since grid-aligned
 
 	-- Pre-allocate 3D arrays with correct Y dimension
 	local materials: { { { Enum.Material } } } = {}


### PR DESCRIPTION
## Summary
- Fixed array dimensions to match Region3:ExpandToGrid() behavior
- Pre-aligned minY and maxY to voxel grid before calculating array sizes

## Problem
The terrain generator was throwing:
```
Bad argument materials[1] to 'WriteVoxels' (151x16 array expected)
```

This was caused by minY=-50 and maxY=550 not being aligned to the voxel grid (voxelSize=4). When `ExpandToGrid()` was called, it expanded the region to align with the grid, resulting in 151 voxels in Y dimension, but our array only had 150.

## Fix
Pre-align the Y bounds to the voxel grid:
- minY = floor(-50/4)*4 = -52
- maxY = ceil(550/4)*4 = 552
- heightRange = 604, voxelsPerAxisY = 151

This ensures the array dimensions exactly match what WriteVoxels expects after ExpandToGrid.

## Test plan
- [ ] Start the game
- [ ] Verify Stage 1 (visual terrain generation) completes without errors
- [ ] Verify terrain appears correctly in the world

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)