### PR TITLE
Fix invisible wall collision issues (Issue #86)

### DIFF
--- a/src/faultline-fear/server/Services/StructureSpawner.luau
+++ b/src/faultline-fear/server/Services/StructureSpawner.luau
@@ -160,6 +160,55 @@ local STRUCTURE_DEFS: { StructureDef } = {
 }
 
 -- ==========================================
+-- COLLISION AUDIT (Fix for Issue #86)
+-- ==========================================
+
+--[[
+	Audit a model for invisible colliders and fix them.
+	A part is considered an "invisible collider" if:
+	- It has CanCollide = true
+	- AND (Transparency >= 0.9 OR it's a MeshPart with no visible mesh)
+
+	This prevents invisible walls blocking player movement.
+]]
+local function auditAndFixInvisibleColliders(model: Model): number
+	local fixed = 0
+
+	for _, part in model:GetDescendants() do
+		if part:IsA("BasePart") and part.CanCollide then
+			local shouldDisableCollision = false
+			local reason = ""
+
+			-- Check for high transparency
+			if part.Transparency >= 0.9 then
+				shouldDisableCollision = true
+				reason = "Transparency >= 0.9"
+			end
+
+			-- Check for MeshParts with no mesh loaded
+			if part:IsA("MeshPart") then
+				-- If MeshId is empty or mesh failed to load, it's invisible
+				if part.MeshId == "" then
+					shouldDisableCollision = true
+					reason = "MeshPart with no MeshId"
+				end
+			end
+
+			if shouldDisableCollision then
+				part.CanCollide = false
+				fixed += 1
+				warn(string.format(
+					"[StructureSpawner] Disabled collision on invisible part '%s' in '%s' (%s)",
+					part.Name, model.Name, reason
+				))
+			end
+		end
+	end
+
+	return fixed
+end
+
+-- ==========================================
 -- PLACEHOLDER CREATION
 -- ==========================================
 
@@ -289,6 +338,12 @@ local function spawnStructure(def: StructureDef): Model?
 
 	-- Parent to folder
 	model.Parent = structuresFolder
+
+	-- Audit for invisible colliders (Fix for Issue #86)
+	local fixedCount = auditAndFixInvisibleColliders(model)
+	if fixedCount > 0 then
+		print(string.format("[StructureSpawner] Fixed %d invisible colliders in %s", fixedCount, def.name))
+	end
 
 	return model
 end

--- a/src/faultline-fear/server/Services/TerrainAssetSpawner.luau
+++ b/src/faultline-fear/server/Services/TerrainAssetSpawner.luau
@@ -305,6 +305,20 @@ local function spawnAsset(placement: AssetPlacement): Model?
 
 	model.Parent = terrainFolder
 
+	-- Audit for invisible colliders
+	for _, part in model:GetDescendants() do
+		if part:IsA("BasePart") and part.CanCollide then
+			-- Disable collision on invisible parts
+			if part.Transparency >= 0.9 then
+				part.CanCollide = false
+			end
+			-- Disable collision on MeshParts with no mesh
+			if part:IsA("MeshPart") and part.MeshId == "" then
+				part.CanCollide = false
+			end
+		end
+	end
+
 	return model
 end
 

--- a/src/faultline-fear/server/Services/ValidationService.luau
+++ b/src/faultline-fear/server/Services/ValidationService.luau
@@ -231,6 +231,71 @@ local function checkPlayerSpawn(): boolean
 	return true
 end
 
+local function checkInvisibleColliders(): boolean
+	-- Scan all workspace parts for invisible colliders (Issue #86)
+	local invisibleColliders: { string } = {}
+
+	local function scanModel(model: Instance, prefix: string)
+		for _, part in model:GetDescendants() do
+			if part:IsA("BasePart") and part.CanCollide then
+				local isInvisible = false
+				local reason = ""
+
+				-- Check transparency
+				if part.Transparency >= 0.9 then
+					isInvisible = true
+					reason = "Transparency"
+				end
+
+				-- Check MeshParts with no mesh
+				if part:IsA("MeshPart") and part.MeshId == "" then
+					isInvisible = true
+					reason = "NoMesh"
+				end
+
+				if isInvisible then
+					table.insert(invisibleColliders, string.format("%s/%s (%s)", prefix, part.Name, reason))
+				end
+			end
+		end
+	end
+
+	-- Check Structures folder
+	local structures = Workspace:FindFirstChild("Structures")
+	if structures then
+		scanModel(structures, "Structures")
+	end
+
+	-- Check TerrainAssets folder
+	local terrainAssets = Workspace:FindFirstChild("TerrainAssets")
+	if terrainAssets then
+		scanModel(terrainAssets, "TerrainAssets")
+	end
+
+	-- Check Signs folder
+	local signs = Workspace:FindFirstChild("Signs")
+	if signs then
+		scanModel(signs, "Signs")
+	end
+
+	if #invisibleColliders > 0 then
+		local message = string.format("Found %d invisible collider(s) that may block player:", #invisibleColliders)
+		for i, collider in ipairs(invisibleColliders) do
+			if i <= 5 then
+				message = message .. "\n  - " .. collider
+			end
+		end
+		if #invisibleColliders > 5 then
+			message = message .. string.format("\n  ... and %d more", #invisibleColliders - 5)
+		end
+		addResult("InvisibleColliders", false, message, "warning")
+		return false
+	end
+
+	addResult("InvisibleColliders", true, "No invisible colliders detected", "info")
+	return true
+end
+
 -- ==========================================
 -- REPORT GENERATION
 -- ==========================================
@@ -320,6 +385,7 @@ function ValidationService:RunValidation(): { ValidationResult }
 	checkRemotes()
 	checkWorkspaceFolders()
 	checkPlayerSpawn()
+	checkInvisibleColliders()
 
 	hasRun = true
 


### PR DESCRIPTION
## Summary
- Add collision auditing system to detect and fix invisible parts with collision enabled
- Addresses the invisible wall near the Ferris Wheel reported in Issue #86
- General-purpose fix that prevents similar issues anywhere in the game

## Changes
- **StructureSpawner**: Add `auditAndFixInvisibleColliders()` function that disables collision on:
  - Parts with Transparency >= 0.9
  - MeshParts with no MeshId (mesh failed to load)
  - Called automatically after spawning each structure

- **TerrainAssetSpawner**: Add inline collision audit after spawning assets

- **ValidationService**: Add `checkInvisibleColliders()` validation check that scans for invisible colliders and reports them in the validation output

## Test plan
- [ ] Run in Roblox Studio - player should be able to walk freely around the Ferris Wheel
- [ ] Check server console for any "[StructureSpawner] Disabled collision on invisible part" warnings (indicates fix was needed)
- [ ] Verify ValidationService reports "No invisible colliders detected" in validation report
- [ ] Run Lune tests: `lune run tests/run.luau` (all pass)
- [ ] Run linter: `selene src/faultline-fear/` (no errors)

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)